### PR TITLE
Fix missing imports and update tests

### DIFF
--- a/backend/app/api/endpoints/models.py
+++ b/backend/app/api/endpoints/models.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException
 from typing import List
+from loguru import logger
 
 from app.core.dependencies import get_current_active_user # For authentication
 from app.db import schemas, models # User model for dependency, schemas for response

--- a/backend/app/plugins/genealogy_research_plugin.py
+++ b/backend/app/plugins/genealogy_research_plugin.py
@@ -1,5 +1,6 @@
 from loguru import logger
 from typing import List, Dict, Any # For type hinting
+import time
 
 from app.plugins.base_plugin import FrankiePlugin
 from app.db import models, crud, schemas # Ensure schemas is imported for ResearchFindingCreate

--- a/backend/app/services/notification_service.py
+++ b/backend/app/services/notification_service.py
@@ -1,5 +1,6 @@
 import smtplib
 from email.message import EmailMessage
+import enum
 from loguru import logger
 
 from app.core.config import settings # To get notification and SMTP settings

--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -4,9 +4,10 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, Session as SQLAlchemySession
 from typing import Generator # For type hinting the fixture
 
-from app.main import app # Import the FastAPI application instance
-from app.core.config import settings # Application settings
-from app.db.database import Base, get_db # Original get_db for overriding
+from app.main import app  # Import the FastAPI application instance
+from app.core.config import settings  # Application settings
+from app.db.database import Base
+from app.core.dependencies import get_db
 
 # Setup a separate test database specifically for these endpoint tests
 SQLALCHEMY_DATABASE_URL_ENDPOINTS = "sqlite:///./test_endpoints_db.db" # Unique name

--- a/backend/tests/test_genealogy.py
+++ b/backend/tests/test_genealogy.py
@@ -2,8 +2,9 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, Session as SQLAlchemySession
-from typing import Generator, Dict, Any # For type hinting
-import os # For file path construction
+from typing import Generator, Dict, Any  # For type hinting
+import os  # For file path construction
+import tempfile
 
 from app.main import app
 from app.core.dependencies import get_db


### PR DESCRIPTION
## Summary
- fix logger import on Ollama models API endpoint
- add time import for GenealogyResearchPlugin
- import enum in NotificationService
- adjust tests to use new get_db path and add missing tempfile import

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q` *(fails: SECRET_KEY validation error during test collection)*

------
https://chatgpt.com/codex/tasks/task_e_687ce4185934832bae7292c1428925ed